### PR TITLE
Fix missing public directory after build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,8 @@
 {
+  "version": 2,
   "cleanUrls": true,
-  "trailingSlash": false
+  "trailingSlash": false,
+  "builds": [
+    { "src": "package.json", "use": "@vercel/next" }
+  ]
 }


### PR DESCRIPTION
Explicitly configure Vercel to use the Next.js builder to resolve the "No Output Directory named 'public' found" deployment error.

Vercel was incorrectly treating the Next.js application as a static site, leading to a build failure. This change forces the correct Next.js runtime.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f0331b6-09cb-4b1f-bd5f-f34e046f9d0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f0331b6-09cb-4b1f-bd5f-f34e046f9d0b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

