### PR TITLE
Fix string pattern mismatch

### DIFF
--- a/app/api/camera/route.ts
+++ b/app/api/camera/route.ts
@@ -53,7 +53,7 @@ function normalize(str: string): string {
 }
 
 export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
+  const searchParams = req.nextUrl.searchParams;
   const query = (searchParams.get("query") || "").trim();
   if (!query) {
     return NextResponse.json({ items: [] }, { status: 200 });


### PR DESCRIPTION
Fix `SyntaxError: The string did not match the expected pattern.` by using `req.nextUrl.searchParams` instead of `new URL(req.url)`.

The `new URL(req.url)` constructor can fail when `req.url` is a relative path, leading to the reported `SyntaxError`. `req.nextUrl.searchParams` correctly extracts search parameters from the Next.js request object, avoiding this issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-6275d93b-8993-4e1a-af59-274ead31e289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6275d93b-8993-4e1a-af59-274ead31e289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

