### PR TITLE
Fix camera model search options display

### DIFF
--- a/components/SetupForm.tsx
+++ b/components/SetupForm.tsx
@@ -151,6 +151,9 @@ export default function SetupForm({ initialLat = "", initialLon = "" }: Props) {
         <label>Camera model (auto-fill sensor)</label>
         <input type="text" value={cameraQuery} onChange={(e) => setCameraQuery(e.target.value)} placeholder="e.g. Nikon D7500, Sony a7 III" />
         {isFetchingCameras && cameraQuery.trim().length >= 2 && <div className="mt-3" style={{ color: "#666" }}>Searching cameras…</div>}
+        {!isFetchingCameras && cameraQuery.trim().length >= 2 && cameraSuggestions.length === 0 && (
+          <div className="mt-3" style={{ color: "#666" }}>No cameras found</div>
+        )}
         {cameraSuggestions.length > 0 && (
           <ul className="mt-3" style={{ padding: 8, border: "1px solid #ddd", borderRadius: 4, listStyle: "none", maxHeight: 180, overflowY: "auto" }}>
             {cameraSuggestions.map((s) => (

--- a/data/cameras.json
+++ b/data/cameras.json
@@ -1,0 +1,7 @@
+[
+  { "brand": "Nikon", "model": "D7500", "sensorW": 23.5, "sensorH": 15.7, "pixelUm": 4.2 },
+  { "brand": "Nikon", "model": "D850", "sensorW": 35.9, "sensorH": 23.9, "pixelUm": 4.35 },
+  { "brand": "Sony", "model": "a7 III", "sensorW": 35.6, "sensorH": 23.8, "pixelUm": 5.94 },
+  { "brand": "Canon", "model": "EOS R6", "sensorW": 35.9, "sensorH": 23.9, "pixelUm": 6.58 },
+  { "brand": "Fujifilm", "model": "X-T4", "sensorW": 23.5, "sensorH": 15.6, "pixelUm": 3.76 }
+]


### PR DESCRIPTION
Add a local fallback camera dataset and "No cameras found" message to improve camera search reliability and user feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b885e62-894e-4767-aa5a-bf0f565bc3f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b885e62-894e-4767-aa5a-bf0f565bc3f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

