### PR TITLE
Investigate recommend targets syntax error

### DIFF
--- a/app/recommend/page.tsx
+++ b/app/recommend/page.tsx
@@ -19,14 +19,21 @@ export default function RecommendPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.sessionStorage.getItem("astro-params") || "");
+    let params: URLSearchParams | null = null;
+    try {
+      const raw = window.sessionStorage.getItem("astro-params") || "";
+      params = new URLSearchParams(raw);
+    } catch {
+      setError("Saved parameters are invalid. Go back and fill the form.");
+      return;
+    }
     if (!params.get("lat") || !params.get("lon")) {
       setError("Missing location/setup. Go back and fill the form.");
       return;
     }
     const qs = params.toString();
     fetch(`/api/recommend?${qs}`, { cache: "no-store" })
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`Request failed: ${r.status}`))))
       .then(setData)
       .catch((e) => setError(String(e)));
   }, []);


### PR DESCRIPTION
Add defensive parsing for `sessionStorage` and `r.ok` check for fetch responses to prevent errors on the Recommend page.

The `SyntaxError: The string did not match the expected pattern` occurred when `sessionStorage.getItem("astro-params")` contained malformed data, which was then passed to `new URLSearchParams()`. The `r.ok` check prevents JSON parsing errors for non-200 HTTP responses from the `/api/recommend` endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b968ede-dfb1-4783-8140-65818dd51dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b968ede-dfb1-4783-8140-65818dd51dcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

